### PR TITLE
Fix for shutting off webcam on indication light after video session is closed

### DIFF
--- a/assets/js/ucc_webrtc.js
+++ b/assets/js/ucc_webrtc.js
@@ -209,6 +209,9 @@ require('./device_manager');
           callbacks[i]();
         }
         WebRTC.yourConnection.close();
+        WebRTC.stream.getTracks().forEach(function (track) {
+          track.stop();
+        });
         if (WebRTC.callType == 'video') {
           WebRTC.connectedUser = null;
           WebRTC.remoteVideo.src = null;


### PR DESCRIPTION
Tested in master branch. The video session is closed and both the webcams are turned off. The far end webpage has the video screens (local & remote) blanked out, and is closed when STOP button is pressed, not sure if this can be closed down through signaling. Opening a new video session, reuses the same video screens. 